### PR TITLE
Fix model normalizer

### DIFF
--- a/squeezenet-burn/src/model/normalizer.rs
+++ b/squeezenet-burn/src/model/normalizer.rs
@@ -26,8 +26,8 @@ impl<B: Backend> Normalizer<B> {
     ///
     /// The normalization is done according to the following formula:
     /// `input = (input - mean) / std`
-    pub fn normalize(self, input: Tensor<B, 4>) -> Tensor<B, 4> {
-        input - self.mean / self.std
+    pub fn normalize(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
+        (input - self.mean.clone()) / self.std.clone()
     }
 }
 


### PR DESCRIPTION
A couple fixes:

1. Instead of taking ownership of self, borrow it.
2. Correct parenthesis for the normalization.